### PR TITLE
Rename function to fix an interface conflict. Fixes #17

### DIFF
--- a/src/main/java/com/mattdahepic/mdecore/command/AbstractCommand.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/AbstractCommand.java
@@ -26,8 +26,8 @@ public abstract class AbstractCommand extends CommandBase {
     public boolean registerCommandLogic (ICommandLogic commandLogic) {
         MDECore.logger.debug("Registering command "+commandLogic.getClass().getName());
         try {
-            if (!commands.containsKey(commandLogic.getCommandName())) {
-                commands.put(commandLogic.getCommandName(), commandLogic);
+            if (!commands.containsKey(commandLogic.getLogicalCommandName())) {
+                commands.put(commandLogic.getLogicalCommandName(), commandLogic);
                 return true;
             }
             return false;
@@ -72,7 +72,7 @@ public abstract class AbstractCommand extends CommandBase {
         if (args.length < 1) args = new String[]{"help"};
         ICommandLogic command = commands.get(args[0]);
         if (command != null) {
-            if (canUseCommand(sender,command.getPermissionLevel(),this,command.getCommandName())) {
+            if (canUseCommand(sender,command.getPermissionLevel(),this,command.getLogicalCommandName())) {
                 command.handleCommand(server,sender,args);
                 return;
             }

--- a/src/main/java/com/mattdahepic/mdecore/command/AbstractHelpLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/AbstractHelpLogic.java
@@ -16,7 +16,7 @@ public abstract class AbstractHelpLogic implements ICommandLogic {
     public abstract AbstractCommand getBaseCommand ();
 
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "help";
     }
     @Override

--- a/src/main/java/com/mattdahepic/mdecore/command/AbstractSingleLogicCommand.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/AbstractSingleLogicCommand.java
@@ -13,6 +13,7 @@ import java.util.List;
 public abstract class AbstractSingleLogicCommand extends CommandBase implements ICommandLogic {
     public abstract int getPermissionLevel ();
     public abstract String getCommandName ();
+    public String getLogicalCommandName () { return getCommandName(); }
     public abstract String getCommandSyntax ();
     public abstract void handleCommand (MinecraftServer server, ICommandSender sender, String[] args) throws CommandException;
     public abstract List<String> getTabCompletionOptions (MinecraftServer server, ICommandSender sender, String[] args, BlockPos pos);

--- a/src/main/java/com/mattdahepic/mdecore/command/ICommandLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/ICommandLogic.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface ICommandLogic {
     int getPermissionLevel ();
-    String getCommandName ();
+    String getLogicalCommandName ();
     String getCommandSyntax ();
     void handleCommand (MinecraftServer server, ICommandSender sender, String[] args) throws CommandException;
     List<String> getTabCompletionOptions (MinecraftServer server, ICommandSender sender, String[] args, BlockPos pos);

--- a/src/main/java/com/mattdahepic/mdecore/command/logic/EnderchestLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/logic/EnderchestLogic.java
@@ -17,7 +17,7 @@ public class EnderchestLogic implements ICommandLogic {
     public static EnderchestLogic instance = new EnderchestLogic();
 
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "enderchest";
     }
     @Override

--- a/src/main/java/com/mattdahepic/mdecore/command/logic/InvseeLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/logic/InvseeLogic.java
@@ -17,7 +17,7 @@ public class InvseeLogic implements ICommandLogic {
     public static InvseeLogic instance = new InvseeLogic();
 
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "invsee";
     }
     @Override

--- a/src/main/java/com/mattdahepic/mdecore/command/logic/KillAllLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/logic/KillAllLogic.java
@@ -21,7 +21,7 @@ public class KillAllLogic implements ICommandLogic {
     public static KillAllLogic instance = new KillAllLogic();
 
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "killall";
     }
     @Override

--- a/src/main/java/com/mattdahepic/mdecore/command/logic/PosLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/logic/PosLogic.java
@@ -17,7 +17,7 @@ public class PosLogic implements ICommandLogic {
     public static PosLogic instance = new PosLogic();
 
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "pos";
     }
     @Override

--- a/src/main/java/com/mattdahepic/mdecore/command/logic/PregenLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/logic/PregenLogic.java
@@ -19,7 +19,7 @@ public class PregenLogic implements ICommandLogic {
     public static PregenLogic instance = new PregenLogic();
 
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "pregen";
     }
     @Override

--- a/src/main/java/com/mattdahepic/mdecore/command/logic/TickrateLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/logic/TickrateLogic.java
@@ -21,7 +21,7 @@ public class TickrateLogic implements ICommandLogic {
     public static TickrateLogic instance = new TickrateLogic();
 
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "tickrate";
     }
     @Override

--- a/src/main/java/com/mattdahepic/mdecore/command/logic/TrimLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/logic/TrimLogic.java
@@ -25,7 +25,7 @@ public class TrimLogic implements ICommandLogic {
     private static boolean hasConfirmed = false;
     
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "trim";
     }
     @Override

--- a/src/main/java/com/mattdahepic/mdecore/command/logic/VersionLogic.java
+++ b/src/main/java/com/mattdahepic/mdecore/command/logic/VersionLogic.java
@@ -16,7 +16,7 @@ public class VersionLogic implements ICommandLogic {
     public static VersionLogic instance = new VersionLogic();
 
     @Override
-    public String getCommandName () {
+    public String getLogicalCommandName () {
         return "version";
     }
     @Override


### PR DESCRIPTION
getCommandName() was conflicting with the built-in getCommandName() from ICommand, so I changed it to getLogicalCommandName().